### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Just clone the repo here and refer to the demo-server.rb file for examples on ho
 	ruby demo-server.rb
 ```
 
-Pocket-Ruby can be installed via the gem, ```gem install pocket-ruby```
+Pocket-Ruby can be installed via the gem, ```gem install pocket-ruby -g pocket```
 
-Or via bundler, ```gem 'pocket-ruby', '~> 0.0.5'```
+Or via bundler, ```gem 'pocket-ruby', '~> 0.0.5', :require => 'pocket'```
+
+Now you're good to go! Just require the gem in your code ```require 'pocket'```


### PR DESCRIPTION
To avoid a 'require' error, you can either change pocket.rb to pocket-ruby.rb, or advise users to :require => 'pocket'
(This is the method I am  using for now. But if you change the main file to pocket-ruby.rb then I think that would be easiest for users)
