### PR TITLE
pocket.rb now called pocket-ruby.rb

### DIFF
--- a/demo-server.rb
+++ b/demo-server.rb
@@ -1,6 +1,6 @@
 require "sinatra"
 
-require "./lib/pocket.rb"
+require "./lib/pocket-ruby.rb"
 
 enable :sessions
 


### PR DESCRIPTION
Correcting a file renaming that has broken the demo-server script. 
