### PR TITLE
fix Pocket::Client::Retrieve#retrieve params default

### DIFF
--- a/lib/pocket/client/retrieve.rb
+++ b/lib/pocket/client/retrieve.rb
@@ -3,7 +3,7 @@ module Pocket
     # http://getpocket.com/developer/docs/v3/retrieve
     module Retrieve
       # required params: consumer_key, access_token
-      def retrieve params=[]
+      def retrieve params={}
         response = connection.post("/v3/get", params)
         response.body
       end


### PR DESCRIPTION
## Goal of this PR

Able to use script like below to send API request without any params:

``` rb
client = Pocket.client(:access_token => "pocket_access_token")
info = client.retrieve
```
## How to reproduce problem

``` rb
client = Pocket.client(:access_token => "pocket_access_token")
info = client.retrieve
```

Result:

``` sh
NoMethodError Exception: undefined method `merge' for []:Array
```
## How to work around

``` rb
client = Pocket.client(:access_token => "pocket_access_token")
info = client.retrieve({})
```
