### PR TITLE
Fixes Retrieve method

### DIFF
--- a/lib/pocket/client/retrieve.rb
+++ b/lib/pocket/client/retrieve.rb
@@ -4,7 +4,7 @@ module Pocket
     module Retrieve
       # required params: consumer_key, access_token
       def retrieve params=[]
-        response = connection.post("/v3/get", params)
+        response = connection.get("/v3/get", params)
         response.body
       end
     end


### PR DESCRIPTION
This changes the call to `/v3/get` to use `GET` instead of `POST`.

The API restricts the API endpoint to use `GET` and will give this confusing error: `This Consumer Key was not found. You can create a Consumer Key at http://getpocket.com/api/`, if `POST` is used.
