### PR TITLE
fix Pocket::Client::Retrieve#retrieve params default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Fix Pocket::Client::Retrieve#retrieve params default ([#12](https://github.com/andyw8/pocket-ruby/pull/12))
+
 ## [0.0.8] - 2021-03-28
 
 - Remove unused Hashie dependency ([#3](https://github.com/andyw8/pocket-ruby/pull/3))

--- a/lib/pocket/client/retrieve.rb
+++ b/lib/pocket/client/retrieve.rb
@@ -3,7 +3,7 @@ module Pocket
     # http://getpocket.com/developer/docs/v3/retrieve
     module Retrieve
       # required params: consumer_key, access_token
-      def retrieve params = []
+      def retrieve params = {}
         response = connection.post("/v3/get", params)
         response.body
       end


### PR DESCRIPTION
See https://github.com/turadg/pocket-ruby/pull/21