### PR TITLE
Fix yard docs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
       power_assert
     tilt (1.4.1)
     unicode-display_width (2.0.0)
+    yard (0.9.26)
 
 PLATFORMS
   x86_64-darwin-19
@@ -72,6 +73,7 @@ DEPENDENCIES
   sinatra (~> 1.3.3)
   standardrb
   test-unit
+  yard
 
 BUNDLED WITH
    2.2.8

--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ rescue LoadError
   # ignore
 else
   YARD::Rake::YardocTask.new do |task|
-    task.files = ["HISTORY.mkd", "LICENSE.mkd", "lib/**/*.rb"]
+    task.files = ["lib/**/*.rb"]
     task.options = [
       "--protected",
       "--output-dir", "doc/yard",

--- a/pocket-ruby.gemspec
+++ b/pocket-ruby.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rake")
   s.add_development_dependency("test-unit")
   s.add_development_dependency("standardrb")
+  s.add_development_dependency("yard")
   s.add_runtime_dependency("faraday", [">= 0.7"])
   s.add_runtime_dependency("faraday_middleware")
   s.add_runtime_dependency("multi_json", ">= 1.0.3", "~> 1.0")


### PR DESCRIPTION
Currently fails with:

```
pocket-ruby master % rake doc:yard 
[warn]: Could not find file: HISTORY.mkd
[warn]: Could not find file: LICENSE.mkd
[warn]: in YARD::Handlers::Ruby::AttributeHandler: Undocumentable Configuration::VALID_OPTIONS_KEYS
        in file 'lib/pocket/api.rb':8:

        8: attr_accessor(*Configuration::VALID_OPTIONS_KEYS)

[warn]: in YARD::Handlers::Ruby::AttributeHandler: Undocumentable VALID_OPTIONS_KEYS
        in file 'lib/pocket/configuration.rb':57:

        57: attr_accessor(*VALID_OPTIONS_KEYS)

[warn]: In file `lib/pocket/client.rb':2: Cannot resolve link to TODO:doc_URL from text:
        ...{TODO:doc_URL the Pocket API Documentation}...
Files:          12
Modules:         7 (    2 undocumented)
Classes:         9 (    1 undocumented)
Constants:      12 (    2 undocumented)
Attributes:      1 (    0 undocumented)
Methods:        41 (   17 undocumented)
 68.57% documented
```