### PR TITLE
Relax `faraday_middleware` version constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## [Unreleased]
+
+- Relax `faraday_middleware` version constraint ([#25](https://github.com/andyw8/pocket-ruby/pull/25))

--- a/pocket-ruby.gemspec
+++ b/pocket-ruby.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('sinatra', '~> 1.3.3')
   s.add_development_dependency('multi_xml')
   s.add_runtime_dependency('faraday', ['>= 0.7'])
-  s.add_runtime_dependency('faraday_middleware', '~> 0.9')
+  s.add_runtime_dependency('faraday_middleware')
   s.add_runtime_dependency('multi_json', '>= 1.0.3', '~> 1.0')
   s.add_runtime_dependency('hashie',  '>= 0.4.0')
   s.authors = ["Turadg Aleahmad","Jason Ng PT"]


### PR DESCRIPTION
Closes #23

Also adds a `CHANGELOG.md` to detail this and future changes.