### PR TITLE
Enable changelog checker GitHub Action

### DIFF
--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -14,6 +14,6 @@ jobs:
         uses: Zomzog/changelog-checker@v1.2.0
         with:
           fileName: CHANGELOG.md
-          checksNotification: Simple
+          checkNotification: Simple
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -1,0 +1,18 @@
+name: changelog-checker
+on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - master
+jobs:
+  build:
+    name: Check Actions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Changelog check
+        uses: Zomzog/changelog-checker@v1.2.0
+        with:
+          fileName: CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -14,5 +14,6 @@ jobs:
         uses: Zomzog/changelog-checker@v1.2.0
         with:
           fileName: CHANGELOG.md
+          checksNotification: Simple
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -14,6 +14,5 @@ jobs:
         uses: Zomzog/changelog-checker@v1.2.0
         with:
           fileName: CHANGELOG.md
-          checkNotification: Simple
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This ensures that changes have a corresponding CHANGELOG entry.

To bypass the check, add the label `no changelog`.

More details: https://github.com/Zomzog/changelog-checker