### PR TITLE
Remove v0.0.5 notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,3 @@ Just clone the repo here and refer to the demo-server.rb file for examples on ho
 Pocket-Ruby can be installed via the gem, ```gem install pocket-ruby```
 
 Or via bundler, ```gem 'pocket-ruby'```
-
-# For v0.0.5 and earlier
-
-Using v0.0.5 and earlier may result in a ```require``` error. To fix this you may either update to a newer version of the gem or uninstall with ```gem uninstall pocket-ruby``` and try again using the method below:
-
-Install via the gem, ```gem install pocket-ruby -v 0.0.5```
-
-Or via bundler, ```gem 'pocket-ruby', '0.0.5', :require => 'pocket'```
-
-Be sure to require the gem in your code with ```require 'pocket'``` not ```require 'pocket-ruby'```


### PR DESCRIPTION
Since v0.0.05 was released 7 years ago, I think it's safe to remove this notice.