### PR TITLE
Remove unused Hashie dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Remove unused Hashie dependency ([#31](https://github.com/turadg/pocket-ruby/pull/31))
+
 ## [0.0.7] - 2021-03-29
 
 - Relax `faraday_middleware` version constraint ([#25](https://github.com/turadg/pocket-ruby/pull/25))


### PR DESCRIPTION
This was added in 59e3d43e5a48b1e79d47caf304ebdcdc130d0d52 but there's no reference to `Hashie` anywhere in the code.

cc @turadg in case I've missed some reason this is needed.