### PR TITLE
Fix Ruby warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 
+- Fix Ruby warnings ([#32](https://github.com/turadg/pocket-ruby/pull/32))
 - Remove unused Hashie dependency ([#31](https://github.com/turadg/pocket-ruby/pull/31))
 
 ## [0.0.7] - 2021-03-29

--- a/lib/pocket/api.rb
+++ b/lib/pocket/api.rb
@@ -5,7 +5,7 @@ module Pocket
   # @private
   class API
     # @private
-    attr_accessor *Configuration::VALID_OPTIONS_KEYS
+    attr_accessor(*Configuration::VALID_OPTIONS_KEYS)
 
     # Creates a new API
     def initialize(options={})

--- a/lib/pocket/configuration.rb
+++ b/lib/pocket/configuration.rb
@@ -53,7 +53,7 @@ module Pocket
     DEFAULT_USER_AGENT = "Pocket Ruby Gem #{Pocket::VERSION}".freeze
 
     # @private
-    attr_accessor *VALID_OPTIONS_KEYS
+    attr_accessor(*VALID_OPTIONS_KEYS)
 
     # When this module is extended, set all configuration options to their default values
     def self.extended(base)

--- a/lib/pocket/oauth.rb
+++ b/lib/pocket/oauth.rb
@@ -15,7 +15,7 @@ module Pocket
       params = access_token_params.merge(options)
       response = connection.post 'oauth/request', params
       results = Hash[URI.decode_www_form(response.body)]
-      code = results['code']
+      results['code']
     end
 
     # Return an access token from authorization
@@ -23,14 +23,14 @@ module Pocket
       params = access_token_params.merge(:code => code).merge(options)
       response = connection.post 'oauth/authorize', params
       results = Hash[URI.decode_www_form(response.body)]
-      access_token = results['access_token']
+      results['access_token']
     end
 
     # Return result from authorization
     def get_result(code, options={})
       params = access_token_params.merge(:code => code).merge(options)
       response = connection.post 'oauth/authorize', params
-      results = Hash[URI.decode_www_form(response.body)]
+      Hash[URI.decode_www_form(response.body)]
     end
 
     private


### PR DESCRIPTION
Fixes these warnings:
```
pocket-ruby master % bundle exec rake test
/Users/andyw8/src/github.com/turadg/pocket-ruby/lib/pocket/configuration.rb:56: warning: `*' interpreted as argument prefix
/Users/andyw8/src/github.com/turadg/pocket-ruby/lib/pocket/api.rb:8: warning: `*' interpreted as argument prefix
/Users/andyw8/src/github.com/turadg/pocket-ruby/lib/pocket/oauth.rb:18: warning: assigned but unused variable - code
/Users/andyw8/src/github.com/turadg/pocket-ruby/lib/pocket/oauth.rb:26: warning: assigned but unused variable - access_token
/Users/andyw8/src/github.com/turadg/pocket-ruby/lib/pocket/oauth.rb:33: warning: assigned but unused variable - results
Loaded suite /Users/andyw8/.gem/ruby/2.6.6/gems/rake-13.0.3/lib/rake/rake_test_loader
```