### PR TITLE
Commit Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
-Gemfile.lock
 # YARD artifacts
 .yardoc
 _yardoc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,50 @@
+PATH
+  remote: .
+  specs:
+    pocket-ruby (0.0.8)
+      faraday (>= 0.7)
+      faraday_middleware
+      hashie (>= 0.4.0)
+      multi_json (~> 1.0, >= 1.0.3)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords
+    faraday-net_http (1.0.1)
+    faraday_middleware (1.0.0)
+      faraday (~> 1.0)
+    hashie (4.1.0)
+    multi_json (1.15.0)
+    multi_xml (0.6.0)
+    multipart-post (2.1.1)
+    power_assert (2.0.0)
+    rack (1.6.13)
+    rack-protection (1.5.5)
+      rack
+    rake (13.0.3)
+    ruby2_keywords (0.0.4)
+    sinatra (1.3.6)
+      rack (~> 1.4)
+      rack-protection (~> 1.3)
+      tilt (~> 1.3, >= 1.3.3)
+    test-unit (3.4.0)
+      power_assert
+    tilt (1.4.1)
+
+PLATFORMS
+  x86_64-darwin-19
+  x86_64-linux
+
+DEPENDENCIES
+  multi_xml
+  pocket-ruby!
+  rake
+  sinatra (~> 1.3.3)
+  test-unit
+
+BUNDLED WITH
+   2.2.8


### PR DESCRIPTION
This has been a lot of debate on this over the years, but I think this post is a good summary of why it should be committed:

https://dragonastronauts.com/2019/08/14/should-you-add-gemfile-lock-to-git/

This has no impact on the users of the gem, only the developers.