### PR TITLE
Add `time_to_read` field for articles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Add `time_to_read` field to `Pocket::Article`. The API does not provide this field, so it is calculated based on 220 words per minute, which should be close the duration shown in the official Pocket clients. ([#50](https://github.com/turadg/pocket-ruby/pull/50))
+
 ## [0.2.1] - 2021-04-10
 
 - Return nil if `time_read` or `time_favorited` is '0' in the API response. Otherwise, this may be interpreted the Unix epoch (1970-01-01). ([#46](https://github.com/turadg/pocket-ruby/pull/46))

--- a/lib/pocket/article.rb
+++ b/lib/pocket/article.rb
@@ -2,6 +2,8 @@ require "json"
 
 module Pocket
   class Article
+    DEFAULT_WORDS_PER_MINUTE = 220
+
     attr_reader :response
 
     def initialize(response)
@@ -116,6 +118,12 @@ module Pocket
 
     def authors
       Hash(response["authors"]).values.map { |value| Pocket::Author.new(value) }
+    end
+
+    def time_to_read(words_per_minute: DEFAULT_WORDS_PER_MINUTE)
+      return nil unless response["word_count"]
+      return nil if word_count == 0
+      word_count.fdiv(words_per_minute).round
     end
   end
 end

--- a/test/pocket/article_test.rb
+++ b/test/pocket/article_test.rb
@@ -152,6 +152,24 @@ module Pocket
       assert_equal [], article.authors
     end
 
+    test "time_to_read" do
+      assert_equal 15, article.time_to_read
+    end
+
+    test "time_to_read with custom value" do
+      assert_equal 29, article.time_to_read(words_per_minute: 110)
+    end
+
+    test "time_to_read returns nil if word_count field not present" do
+      parsed_response.delete("word_count")
+      assert_nil article.time_to_read
+    end
+
+    test "time_to_read returns nil if word_count is 0" do
+      parsed_response["word_count"] = "0"
+      assert_nil article.time_to_read
+    end
+
     private
 
     def article


### PR DESCRIPTION
The API does not provide this field, so it is calculated based on 220 words per minute, which should be close the duration shown in the official Pocket clients.