### PR TITLE
Remove redundant gemspec entry

### DIFF
--- a/pocket-ruby.gemspec
+++ b/pocket-ruby.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.require_paths = ["lib"]
   s.required_rubygems_version = Gem::Requirement.new(">= 1.3.6") if s.respond_to? :required_rubygems_version=
-  s.rubyforge_project = s.name
   s.summary = "Ruby wrapper for the Pocket API v3"
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.version = Pocket::VERSION


### PR DESCRIPTION
Rubyforge no longer exists.