### PR TITLE
Use dynamic matrix for CI Ruby versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,14 +3,25 @@ name: Ruby
 on: [push,pull_request]
 
 jobs:
-  build:
+  build-matrix:
     runs-on: ubuntu-latest
+    steps: # https://michaelheap.com/dynamic-matrix-generation-github-actions/
+    - id: set-matrix
+      run: echo "::set-output name=version_matrix::$(curl https://endoflife.date/api/ruby.json | jq -c '[.[] | select(.eol > (now | strftime("%Y-%m-%d"))) | .cycle]')"
+    outputs:
+      version_matrix: ${{ steps.set-matrix.outputs.version_matrix }}
+  ci:
+    needs: build-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ${{ fromJson(needs.build-matrix.outputs.version_matrix) }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.6
+        ruby-version: ${{ matrix.version }}
         bundler-cache: true
     - name: Run the default task
       run: bundle exec rake


### PR DESCRIPTION
This reduces the need to manually keep track of new or EOL Ruby releases.
Based on https://michaelheap.com/dynamic-matrix-generation-github-actions/

At present the tests versions are:

```
$ curl https://endoflife.date/api/ruby.json | jq -c '[.[] | select(.eol > (now | strftime("%Y-%m-%d"))) | .cycle]'
["3.0","2.7","2.6"]
```