### PR TITLE
Use minitest (via ActiveSupport)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,9 +9,16 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.1.4.6)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
     docile (1.3.5)
@@ -27,6 +34,9 @@ GEM
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     hashdiff (1.0.1)
+    i18n (1.10.0)
+      concurrent-ruby (~> 1.0)
+    minitest (5.15.0)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
@@ -35,7 +45,6 @@ GEM
     parallel (1.21.0)
     parser (3.1.1.0)
       ast (~> 2.4.1)
-    power_assert (2.0.0)
     public_suffix (4.0.6)
     rack (2.2.3)
     rack-protection (2.1.0)
@@ -74,15 +83,16 @@ GEM
     standard (1.7.2)
       rubocop (= 1.25.1)
       rubocop-performance (= 1.13.2)
-    test-unit (3.4.0)
-      power_assert
     tilt (2.0.10)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
     webmock (3.12.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     yard (0.9.26)
+    zeitwerk (2.5.4)
 
 PLATFORMS
   universal-darwin-21
@@ -91,13 +101,13 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activesupport (~> 6.1)
   multi_xml
   pocket-ruby!
   rake
   simplecov
   sinatra (~> 2)
   standard
-  test-unit
   webmock
   yard
 

--- a/pocket-ruby.gemspec
+++ b/pocket-ruby.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("multi_xml")
   s.add_development_dependency("rake")
   s.add_development_dependency("standard")
-  s.add_development_dependency("test-unit")
+  s.add_development_dependency("activesupport", "~> 6.1") # move to v7 once support for Ruby 2.6 is dropped
   s.add_development_dependency("simplecov")
   s.add_development_dependency("webmock")
   s.add_development_dependency("yard")

--- a/test/pocket/article_test.rb
+++ b/test/pocket/article_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 module Pocket
-  class ArticleTest < Test::Unit::TestCase
+  class ArticleTest < ActiveSupport::TestCase
     setup do
       @article = Pocket::Article.new(parsed_response)
     end
@@ -51,7 +51,7 @@ module Pocket
     end
 
     test "excerpt" do
-      assert_include @article.excerpt, "list of things"
+      assert_includes @article.excerpt, "list of things"
     end
 
     test "excerpt is nil if field not present" do

--- a/test/pocket/client_test.rb
+++ b/test/pocket/client_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
-require "webmock/test_unit"
+require "webmock/minitest"
 
-class ClientTest < Test::Unit::TestCase
+class ClientTest < ActiveSupport::TestCase
   test "retrieve" do
     stub_request(:post, "https://getpocket.com/v3/get")
       .with(

--- a/test/pocket/version_test.rb
+++ b/test/pocket/version_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 module Pocket
-  class VersionTest < Test::Unit::TestCase
+  class VersionTest < ActiveSupport::TestCase
     def test_specifies_a_version
       assert Pocket::VERSION
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,4 +8,6 @@ end
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "pocket-ruby"
 
-require "test-unit"
+require "active_support"
+require "active_support/test_case"
+require "minitest/autorun"


### PR DESCRIPTION
The current test framework, `test-unit`, is an older Ruby framework which has been largely succeeded by minitest.

However, minitest does not have built-in support for the 'declarative' style testing that `test-unit` offered (e.g. `test "it works..." do`), so I have chosen to use minitest via ActiveSupport which adds this enhancement.

Although there is often hesitancy about adding ActiveSupport as a dependency, here is being used for the tests only and won't ship with the gem.