### PR TITLE
Prevent YARD `Undocumentable` warnings for `attr_accessor` splat

### DIFF
--- a/lib/pocket/api.rb
+++ b/lib/pocket/api.rb
@@ -5,7 +5,14 @@ module Pocket
   # @private
   class API
     # @private
-    attr_accessor(*Configuration::VALID_OPTIONS_KEYS)
+    attr_accessor :adapter,
+      :consumer_key,
+      :access_token,
+      :endpoint,
+      :redirect_uri,
+      :format,
+      :user_agent,
+      :proxy
 
     # Creates a new API
     def initialize(options = {})

--- a/lib/pocket/configuration.rb
+++ b/lib/pocket/configuration.rb
@@ -54,7 +54,14 @@ module Pocket
     DEFAULT_USER_AGENT = "Pocket Ruby Gem #{Pocket::VERSION}".freeze
 
     # @private
-    attr_accessor(*VALID_OPTIONS_KEYS)
+    attr_accessor :adapter,
+      :consumer_key,
+      :access_token,
+      :endpoint,
+      :redirect_uri,
+      :format,
+      :user_agent,
+      :proxy
 
     # When this module is extended, set all configuration options to their default values
     def self.extended(base)


### PR DESCRIPTION
Prevents:
  ```
  [warn]: in YARD::Handlers::Ruby::AttributeHandler: Undocumentable VALID_OPTIONS_KEYS
  ```